### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ See a demo of DociQL in action here: [https://wayfair.github.io/dociql/](https:/
 ### Install DociQL from `npm`:
 
 ```bash
-npm install -g dociql-docs
+npm install -g dociql
 ```
 
 


### PR DESCRIPTION
It looks like the package is published as `dociql`, not `dociql-docs`
https://www.npmjs.com/package/dociql