### PR TITLE
Several fixes and improvements

### DIFF
--- a/app/lib/preprocessor.js
+++ b/app/lib/preprocessor.js
@@ -77,6 +77,14 @@ module.exports = function(options, specData) {
   var replaceRefs = require("./resolve-references").replaceRefs;
   replaceRefs(path.dirname(copy["x-spec-path"]), copy, copy, "")
 
+  var names = Object.keys(copy.definitions);
+  names.sort();
+  var sortedDefinitions = {};
+  for (const name of names) {
+    sortedDefinitions[name] = copy.definitions[name];
+  }
+  copy.definitions = sortedDefinitions;
+
   return copy;
 }
 

--- a/app/lib/preprocessor.js
+++ b/app/lib/preprocessor.js
@@ -77,13 +77,15 @@ module.exports = function(options, specData) {
   var replaceRefs = require("./resolve-references").replaceRefs;
   replaceRefs(path.dirname(copy["x-spec-path"]), copy, copy, "")
 
-  var names = Object.keys(copy.definitions);
-  names.sort();
-  var sortedDefinitions = {};
-  for (const name of names) {
-    sortedDefinitions[name] = copy.definitions[name];
+  if (copy.definitions) {
+    var names = Object.keys(copy.definitions);
+    names.sort();
+    var sortedDefinitions = {};
+    for (const name of names) {
+      sortedDefinitions[name] = copy.definitions[name];
+    }
+    copy.definitions = sortedDefinitions;
   }
-  copy.definitions = sortedDefinitions;
 
   return copy;
 }

--- a/app/views/partials/swagger/request-body.hbs
+++ b/app/views/partials/swagger/request-body.hbs
@@ -40,7 +40,7 @@
         {{else if schema.description}}
           {{md schema.description}}
         {{/if}}
-        {{>json-schema/body schema}}
+        {{!-- {{>json-schema/body schema}} --}}
       {{/if}}
     {{/with}}
   {{/if}}

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "commander": "*",
     "foundation-sites": "^6.5.0-rc.4",
     "graphql": "^14.1.1",
-    "graphql-2-json-schema": "^0.1.1",
+    "graphql-2-json-schema": "^0.2.0",
     "graphql-json-schema": "^0.1.2",
     "grunt": "^1.0.4",
     "grunt-compile-handlebars": "^2.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1075,10 +1075,10 @@ graphlib@^2.1.1:
   dependencies:
     lodash "^4.17.5"
 
-graphql-2-json-schema@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/graphql-2-json-schema/-/graphql-2-json-schema-0.1.1.tgz#77e1f9b2b9513bd38ac9e751e7e6f1096399a89f"
-  integrity sha512-Vy4gafvd1se+06QJgoVqjBwGrdpcp+MQ4t08U9Bb9FHvLJm3ZauISp72yXVyT9bj+BUkomaBeayGyedGiFfUOA==
+graphql-2-json-schema@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.npmjs.org/graphql-2-json-schema/-/graphql-2-json-schema-0.2.0.tgz#ef02d7d422071be199bfb4d3c6719f3431005661"
+  integrity sha512-INEySjzTCb+oI8RTVBGQDHBgOiXtHlcR47MKvyWtaiJbptUBUXHlfO1njI89NeU+KIF6cUnAqmKgyYgyJVYwbA==
   dependencies:
     functional-json-schema "0.0.2-3"
     lodash "^4.17.10"


### PR DESCRIPTION
- Alphabetize the `definitions`. I don't know why anyone wouldn't want to do this, but this could be put behind an option if it's controversial
- Update to latest `graphql-2-json-schema` package, which causes custom and built-in scalars to appear in the docs correctly
- Comment out `{{>json-schema/body schema}}` in the request body because it seems to be duplicate and unstyled content that isn't needed.