### PR TITLE
fix: render deeply wrapped fields in example query

### DIFF
--- a/app/dociql/generate-example.js
+++ b/app/dociql/generate-example.js
@@ -28,7 +28,11 @@ function generateQueryInternal(field, expandGraph, arguments, depth, typeCounts 
         queryStr += `(${argsStr})`;
     }
 
-    var returnType = field.type.ofType || field.type;
+    var returnType = field.type;
+
+    while(returnType.ofType) {
+        returnType = returnType.ofType;
+    };
 
     if (returnType.getFields) {
         var subQuery = null;

--- a/app/dociql/generate-example.js
+++ b/app/dociql/generate-example.js
@@ -32,7 +32,7 @@ function generateQueryInternal(field, expandGraph, arguments, depth, typeCounts 
 
     while(returnType.ofType) {
         returnType = returnType.ofType;
-    };
+    }
 
     if (returnType.getFields) {
         var subQuery = null;


### PR DESCRIPTION
There is a bug we found were if you have a double nested wrapping it will not render that in the docs query example.
As far as we can tell this will only come up when you have a required array or required array fields.

All this pr does is read all the way down the wrappings till it gets to the actual type, so the types below are rendered correctly.

Example config:
```
domains:
  - name: API
    description: Description
    usecases:
      - name: Get Options
        description: Example
        query: query.options
        select: description
```

Schemas that work today (all one deep):
       - options: [Option]
       - option: Option!

Generated Example Query
![Screen Shot 2020-10-28 at 8 43 42 AM](https://user-images.githubusercontent.com/73594653/97444888-a12e7880-18fa-11eb-9ec4-12426f2c783f.png)

Schemas that do not work:
       - options: [Option]! (two deep, fails when using expand)
       - options: [Option!] (two deep, fails when using expand)
       - options: [Option!]! (three deep, fails at top level and expand)

Generated Example Query
![Screen Shot 2020-10-28 at 8 47 43 AM](https://user-images.githubusercontent.com/73594653/97444931-ad1a3a80-18fa-11eb-9609-33239fa32453.png)
