### PR TITLE
feature: Add operation name "IntrospectionQuery" to the request

### DIFF
--- a/app/dociql/fetch-schema.js
+++ b/app/dociql/fetch-schema.js
@@ -6,6 +6,7 @@ const converter = require('graphql-2-json-schema');
 module.exports = function (graphUrl) {
 
     const requestBody = {
+        operationName: "IntrospectionQuery",
         query: graphql.introspectionQuery
     };
 


### PR DESCRIPTION
Although being optional, it can be a problem to not have the operationName defined in some server implementations. So it does not hurt to include it by default.