### PR TITLE
Add dynamic headers

### DIFF
--- a/app/dociql/fetch-schema.js
+++ b/app/dociql/fetch-schema.js
@@ -10,10 +10,10 @@ module.exports = function (graphUrl, authHeader) {
         query: graphql.introspectionQuery
     };
 
+    const headers = Object.fromEntries([authHeader.split(":")]);
+
     const responseBody = request("POST", graphUrl, {
-        headers: {
-            authorization: authHeader,
-        },
+        headers,
         json: requestBody
     }).getBody('utf8');
 


### PR DESCRIPTION
Hi,

The aim of this PR is to add the possibility to add other auth headers to GraphQL request and not only ```authorization``` header.

it could be helpful if we use X-API-KEY to secure our GraphQL API.

```
dociql -d config.yml -H "x-api-key: MY_API_KEY"
dociql -d config.yml -H "authorization: MY_AUTHORIZATION_HEADER"
```

Enjoy