### PR TITLE
Add -H header option to readme description

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ $ dociql -h
   Options:
 
     -h, --help                   output usage information
+    -H, --header                 specify a custom auth token for the header (default: none)
     -V, --version                output the version number
     -C, --disable-css            omit CSS generation (default: false)
     -J, --disable-js             omit JavaScript generation (default: false)


### PR DESCRIPTION
Adds the -H and --header flag to the readme documentation (copy and pasted from the description in source code)

EDIT:  It would be really nice to have this in the YAML file as putting a giant token string in my package.json isn't exactly ideal (even if it is expired).  I can potentially add this as well but I need to dig into the code base a bit more, I saw this as an easy improvement so just picking the low hanging fruit.