### PR TITLE
Add support for generating docs from a GraphQL SDL file

### DIFF
--- a/app/dociql/fetch-schema.js
+++ b/app/dociql/fetch-schema.js
@@ -1,9 +1,36 @@
-const { getIntrospectionQuery, buildClientSchema } = require('graphql')
+const { graphqlSync, buildSchema, getIntrospectionQuery, buildClientSchema } = require('graphql')
 const request = require("sync-request")
+const fs = require('fs');
 
 const converter = require('graphql-2-json-schema');
 
 module.exports = function (graphUrl, authHeader) { 
+    if (graphUrl.includes("file://")) {
+        return fetchSchemaFromFile(graphUrl);
+    } else {
+        return fetchSchemaFromUrl(graphUrl, authHeader);
+    }
+    
+
+}
+
+function fetchSchemaFromFile(graphUrl) {
+  const filePath = graphUrl.replace("file://", "");
+  const fileContent = fs.readFileSync(filePath, "utf-8");
+
+  const graphQLSchema = buildSchema(fileContent);
+  
+  const introspection = graphqlSync(graphQLSchema, getIntrospectionQuery()).data;
+
+  const jsonSchema = converter.fromIntrospectionQuery(introspection);
+
+  return {
+    jsonSchema,
+    graphQLSchema
+  }
+}
+
+function fetchSchemaFromUrl(graphUrl, authHeader) {
     const requestBody = {
         operationName: "IntrospectionQuery",
         query: getIntrospectionQuery()

--- a/app/dociql/fetch-schema.js
+++ b/app/dociql/fetch-schema.js
@@ -17,8 +17,14 @@ module.exports = function (graphUrl, authHeader) {
 function fetchSchemaFromFile(graphUrl) {
   const filePath = graphUrl.replace("file://", "");
   const fileContent = fs.readFileSync(filePath, "utf-8");
+  let graphQLSchema;
 
-  const graphQLSchema = buildSchema(fileContent);
+  try {
+    graphQLSchema = buildSchema(fileContent);
+  } catch (e) {
+    console.error(`Encountered an error parsing the schema file. Is ${filePath} in GraphQL SDL format?`);
+    throw e;
+  }
   
   const introspection = graphqlSync(graphQLSchema, getIntrospectionQuery()).data;
 


### PR DESCRIPTION
This PR adds support for generating docs from a GraphQL SDL file, simply by specifying a `file://` path in the `introspection:` configuration parameter or in the `-u` command line option.

Note that the source file must be in GraphQL SDL format, not JSON format. This change will print a helpful error message if it runs into trouble parsing the schema, asking the user to ensure it's in the correct format.

Fixes #27 