### PR TITLE
Fix invalid closing link

### DIFF
--- a/app/helpers/getTryItNow.js
+++ b/app/helpers/getTryItNow.js
@@ -14,5 +14,5 @@ module.exports = function (value, options) {
     const variablesQuery = variables ? `&variables=${encodeURIComponent(variables)}` : ""
 
     var url = `${options.data.root.servers[0].url}?query=${encodeURIComponent(query)}${variablesQuery}`;
-    return new Handlebars.SafeString(`<a href="${url}" target="_blank">Try it now<a/>\n`);
+    return new Handlebars.SafeString(`<a href="${url}" target="_blank">Try it now</a>\n`);
 }


### PR DESCRIPTION
Fixes #39

sometimes such invalid markup leads to wrong content display. The contents of the left column is shown in the right column.

<img width="1220" alt="ScreenShot 2021-11-01 в 19 21 20" src="https://user-images.githubusercontent.com/621014/139705696-507d1be6-da9c-489e-bf95-008ae4b3be85.png">


